### PR TITLE
Store most recent Resources and Details on Finding Events table

### DIFF
--- a/cmd/vulnerability-db-consumer/config.go
+++ b/cmd/vulnerability-db-consumer/config.go
@@ -42,11 +42,13 @@ type sqsConfig struct {
 	WaitTime    uint8 `toml:"wait_time"`
 	Timeout     uint8
 	QueueARN    string `toml:"queue_arn"`
+	Endpoint    string `toml:"endpoint"`
 }
 
 type snsConfig struct {
 	TopicARN string `toml:"topic_arn"`
 	Enabled  bool
+	Endpoint string `toml:"endpoint"`
 }
 
 type reportConfig struct {

--- a/cmd/vulnerability-db-consumer/main.go
+++ b/cmd/vulnerability-db-consumer/main.go
@@ -46,6 +46,7 @@ func main() {
 	snsConf := notify.SNSConfig{
 		TopicArn: conf.SNS.TopicARN,
 		Enabled:  conf.SNS.Enabled,
+		Endpoint: conf.SNS.Endpoint,
 	}
 	snsNotifier, err := notify.NewSNSNotifier(snsConf, logger)
 	if err != nil {
@@ -68,6 +69,7 @@ func main() {
 		QueueArn:    conf.SQS.QueueARN,
 		Timeout:     int64(conf.SQS.Timeout),
 		MaxWaitTime: int64(conf.SQS.WaitTime),
+		Endpoint:    conf.SQS.Endpoint,
 	}
 	sqsConsumerGroup, err := queue.NewSQSConsumerGroup(conf.SQS.NProcessors, sqsConf, processor, logger)
 	if err != nil {

--- a/db/sql/V1.20__add_details_and_resources_to_finding_events.sql
+++ b/db/sql/V1.20__add_details_and_resources_to_finding_events.sql
@@ -1,0 +1,3 @@
+ALTER TABLE finding_events ADD COLUMN details TEXT;
+ALTER TABLE finding_events ADD COLUMN resources jsonb;
+

--- a/pkg/notify/sns.go
+++ b/pkg/notify/sns.go
@@ -20,6 +20,7 @@ import (
 type SNSConfig struct {
 	TopicArn string `mapstructure:"topic_arn"`
 	Enabled  bool   `mapstructure:"enabled"`
+	Endpoint string `mapstructure:"endpoint"`
 }
 
 // SNSNotifier sends push events to an SNS topic.
@@ -37,7 +38,14 @@ func NewSNSNotifier(conf SNSConfig, logger *log.Logger) (*SNSNotifier, error) {
 	}
 
 	qd := parseSNSARN(conf.TopicArn)
-	srv := sns.New(sess, aws.NewConfig().WithEndpoint(qd.endpoint).WithRegion(qd.region))
+
+	endpoint := qd.endpoint
+
+	if conf.Endpoint != "" {
+		endpoint = conf.Endpoint
+	}
+
+	srv := sns.New(sess, aws.NewConfig().WithEndpoint(endpoint).WithRegion(qd.region))
 
 	notifier := &SNSNotifier{
 		conf:   conf,

--- a/pkg/queue/sqs.go
+++ b/pkg/queue/sqs.go
@@ -28,6 +28,7 @@ type SQSConfig struct {
 	QueueArn    string
 	Timeout     int64
 	MaxWaitTime int64
+	Endpoint    string
 }
 
 // SQSConsumer is the SQS implementation of the QueueConsumer interface.
@@ -78,7 +79,13 @@ func NewSQSConsumerGroup(nConsumers uint8, config SQSConfig, processor Processor
 
 // newSQSConsumer creates a new SQSConsumer reusing an existent AWS session.
 func newSQSConsumer(awsSess *session.Session, awsData awsData, config SQSConfig, processor Processor, logger *log.Logger) (*SQSConsumer, error) {
-	sqsSvc := sqs.New(awsSess, aws.NewConfig().WithEndpoint(awsData.sqsEndpoint).WithRegion(awsData.region))
+	endpoint := awsData.sqsEndpoint
+
+	if config.Endpoint != "" {
+		endpoint = config.Endpoint
+	}
+
+	sqsSvc := sqs.New(awsSess, aws.NewConfig().WithEndpoint(endpoint).WithRegion(awsData.region))
 	sqsURLData, err := sqsSvc.GetQueueUrl(&sqs.GetQueueUrlInput{QueueName: aws.String(awsData.sqsName)})
 	if err != nil {
 		return nil, err

--- a/pkg/store/findings.go
+++ b/pkg/store/findings.go
@@ -40,10 +40,14 @@ type Finding struct {
 // which can indicate the finding has been found
 // or it has been fixed.
 type FindingEvent struct {
-	ID        string    `db:"id"`
-	FindingID string    `db:"finding_id"`
-	SourceID  string    `db:"source_id"`
-	Score     float64   `db:"score"`
+	ID        string  `db:"id"`
+	FindingID string  `db:"finding_id"`
+	SourceID  string  `db:"source_id"`
+	Score     float64 `db:"score"`
+	Details   *string `db:"details"`
+	// Resources contains the vulnerability resources tables mashalled into a
+	// json.
+	Resources *[]byte   `db:"resources"`
 	Time      time.Time `db:"time"`
 }
 
@@ -57,16 +61,20 @@ type FindingExposure struct {
 }
 
 type findingState struct {
-	ID       string
-	Exposure []FindingExposure
-	Status   string
-	Score    float64
+	ID        string
+	Exposure  []FindingExposure
+	Status    string
+	Score     float64
+	Details   *string
+	Resources *[]byte
 }
 
 type sourceFindings struct {
 	FindingID  *string   `db:"finding_id"`
 	SourceID   string    `db:"source_id"`
 	SourceTime time.Time `db:"source_time"`
+	Resources  *[]byte   `db:"resources"`
+	Details    *string   `db:"details"`
 	Score      *float64  `db:"score"`
 }
 
@@ -77,9 +85,11 @@ type findingData struct {
 }
 
 type timeEvent struct {
-	T     time.Time
-	score float64
-	found bool
+	T         time.Time
+	score     float64
+	details   *string
+	resources *[]byte
+	found     bool
 }
 
 type timeline []timeEvent
@@ -94,14 +104,18 @@ func (t timeline) findNext(i int, cond func(timeEvent) bool) (int, bool) {
 	return i, found
 }
 
-func (t timeline) LastFoundScore() float64 {
+func (t timeline) LastFoundScore() (float64, *string, *[]byte) {
 	var score float64
+	var details *string
+	var resources *[]byte
 	for _, s := range t {
 		if s.found {
 			score = s.score
+			details = s.details
+			resources = s.resources
 		}
 	}
-	return score
+	return score, details, resources
 }
 
 // CreateFinding creates a new finding and also a new fiding event for that finding.
@@ -297,7 +311,7 @@ func (db *psqlxStore) RecalculateFindingsStatus(s SourceFamily) error {
 
 // createFindingEvent creates a finding event for the given finding. It creates the
 // finding if it does not exist.
-func createFindingEvent(ctx context.Context, tx *sqlx.Tx, f Finding, s Source, score float32) (*FindingEvent, error) {
+func createFindingEvent(ctx context.Context, tx *sqlx.Tx, f Finding, s Source, score float32, resources *[]byte, details string) (*FindingEvent, error) {
 	// Ensure finding for the finding event exists.
 	q := `
 	WITH  q as (
@@ -321,8 +335,8 @@ func createFindingEvent(ctx context.Context, tx *sqlx.Tx, f Finding, s Source, s
 
 	// Create the finding event.
 	var findingEvent FindingEvent
-	r := tx.QueryRowxContext(ctx, `INSERT INTO finding_events (finding_id, source_id, time, score)
-		VALUES ($1, $2, $3, $4) RETURNING *`, f.ID, s.ID, s.Time, score)
+	r := tx.QueryRowxContext(ctx, `INSERT INTO finding_events (finding_id, source_id, time, score, resources, details)
+		VALUES ($1, $2, $3, $4, $5, $6) RETURNING *`, f.ID, s.ID, s.Time, score, f.Resources, f.Details)
 	err = r.StructScan(&findingEvent)
 	return &findingEvent, err
 }
@@ -342,7 +356,7 @@ func findingsStates(ctx context.Context, tx *sqlx.Tx, log *log.Logger, s SourceF
 				)
 			)                                                       
 		)
-		SELECT fe.finding_id as finding_id, fe.score as score, s.id as source_id, s.time as source_time
+		SELECT fe.finding_id as finding_id, fe.score as score, fe.details as details, fe.resources as resources, s.id as source_id, s.time as source_time
 		FROM relevant_sources s LEFT JOIN finding_events fe
 		ON fe.source_id=s.id LEFT JOIN findings f ON f.id=fe.finding_id
 		ORDER BY fe.finding_id, s.time;
@@ -418,6 +432,8 @@ func buildFindingStates(sourceF []sourceFindings) []findingState {
 			Time:      sf.SourceTime,
 			SourceID:  sf.SourceID,
 			Score:     *sf.Score,
+			Details:   sf.Details,
+			Resources: sf.Resources,
 		})
 		found[sf.SourceID] = struct{}{}
 	}
@@ -492,12 +508,14 @@ func buildFindingStates(sourceF []sourceFindings) []findingState {
 		if exposures[len(exposures)-1].FixedAT != nil {
 			status = FindingStatusFixed
 		}
-		score := tl.LastFoundScore()
+		score, details, resources := tl.LastFoundScore()
 		state := findingState{
-			Exposure: exposures,
-			ID:       id,
-			Score:    score,
-			Status:   status,
+			Exposure:  exposures,
+			ID:        id,
+			Score:     score,
+			Details:   details,
+			Resources: resources,
+			Status:    status,
 		}
 		findingStates = append(findingStates, state)
 	}
@@ -515,9 +533,13 @@ func buildFindingTimeline(f findingData) timeline {
 	for i < len(f.Events) || j < len(f.NotFound) {
 		var tf, tnf *time.Time
 		var score float64
+		var details *string
+		var resources *[]byte
 		if i < len(f.Events) {
 			tf = &f.Events[i].Time
 			score = f.Events[i].Score
+			details = f.Events[i].Details
+			resources = f.Events[i].Resources
 		}
 		if j < len(f.NotFound) {
 			tnf = &f.NotFound[j].Time
@@ -525,9 +547,11 @@ func buildFindingTimeline(f findingData) timeline {
 		if tf != nil && tnf != nil {
 			if tf.Before(*tnf) {
 				tl = append(tl, timeEvent{
-					T:     *tf,
-					found: true,
-					score: score,
+					T:         *tf,
+					found:     true,
+					score:     score,
+					details:   details,
+					resources: resources,
 				})
 				i++
 			} else {
@@ -541,9 +565,11 @@ func buildFindingTimeline(f findingData) timeline {
 		}
 		if tf != nil {
 			tl = append(tl, timeEvent{
-				T:     *tf,
-				found: true,
-				score: score,
+				T:         *tf,
+				found:     true,
+				score:     score,
+				details:   details,
+				resources: resources,
 			})
 			i++
 			continue
@@ -560,9 +586,9 @@ func buildFindingTimeline(f findingData) timeline {
 func replaceFindingsState(ctx context.Context, tx *sqlx.Tx, log *log.Logger, states []findingState) error {
 	qd := "DELETE FROM finding_exposures where finding_id = $1"
 	di := "INSERT INTO finding_exposures(finding_id,found_at,fixed_at,ttr) VALUES ($1, $2, $3, $4)"
-	qF := "UPDATE findings SET status=$1, score=$2 WHERE id=$3"
+	qF := "UPDATE findings SET status=$1, score=$2, resources=COALESCE($3, resources), details=COALESCE($4, details) WHERE id=$5"
 	for _, s := range states {
-		_, err := tx.Exec(qF, s.Status, s.Score, s.ID)
+		_, err := tx.Exec(qF, s.Status, s.Score, s.Resources, s.Details, s.ID)
 		if err != nil {
 			return err
 		}

--- a/pkg/store/findings.go
+++ b/pkg/store/findings.go
@@ -104,7 +104,7 @@ func (t timeline) findNext(i int, cond func(timeEvent) bool) (int, bool) {
 	return i, found
 }
 
-func (t timeline) LastFoundScore() (float64, *string, *[]byte) {
+func (t timeline) LastFoundAttributes() (float64, *string, *[]byte) {
 	var score float64
 	var details *string
 	var resources *[]byte
@@ -508,7 +508,7 @@ func buildFindingStates(sourceF []sourceFindings) []findingState {
 		if exposures[len(exposures)-1].FixedAT != nil {
 			status = FindingStatusFixed
 		}
-		score, details, resources := tl.LastFoundScore()
+		score, details, resources := tl.LastFoundAttributes()
 		state := findingState{
 			Exposure:  exposures,
 			ID:        id,

--- a/pkg/store/sources.go
+++ b/pkg/store/sources.go
@@ -144,7 +144,7 @@ func (db *psqlxStore) ProcessSourceExecution(s Source, sourceFindings []SourceFi
 			ImpactDetails: sf.ImpactDetails,
 			Resources:     sf.Resources,
 		}
-		fe, err := createFindingEvent(ctx, tx, f, *screated, sf.Score)
+		fe, err := createFindingEvent(ctx, tx, f, *screated, sf.Score, sf.Resources, sf.Details)
 		if err != nil {
 			tx.Rollback() // nolint
 			return Source{}, err

--- a/test/processor_integration_test.go
+++ b/test/processor_integration_test.go
@@ -128,15 +128,19 @@ func TestProcessor(t *testing.T) {
 				expectedData{
 					table: findingsTable,
 					data: map[string]interface{}{
-						"status": "OPEN",
-						"score":  float64(8.0),
+						"status":    "OPEN",
+						"score":     float64(8.0),
+						"details":   "Managed AWS details",
+						"resources": []byte(`[{"name": "resource name", "resources": null, "attributes": null}]`),
 					},
 				},
 				expectedData{
 					table: fEventsTable,
 					data: map[string]interface{}{
-						"score": float64(8.0),
-						"time":  "2020-01-21 16:03:25",
+						"time":      "2020-01-21 16:03:25",
+						"score":     float64(8.0),
+						"details":   "Managed AWS details",
+						"resources": []byte(`[{"name": "resource name", "resources": null, "attributes": null}]`),
 					},
 				},
 				expectedData{
@@ -199,6 +203,9 @@ func TestProcessor(t *testing.T) {
 						"issue_id":  "c0000000-0000-0000-0000-000000000001",
 						"target_id": "a0000000-0000-0000-0000-000000000001",
 						"status":    "OPEN",
+						"score":     float64(7.0),
+						"details":   "Managed AWS details - modified",
+						"resources": []byte(`[{"name": "resource name", "resources": [{"CVE": "CVE-2009-3023"}], "attributes": ["CVE"]}]`),
 					},
 				},
 				expectedData{
@@ -212,8 +219,10 @@ func TestProcessor(t *testing.T) {
 				expectedData{
 					table: fEventsTable,
 					data: map[string]interface{}{
-						"score": float64(7.0),
-						"time":  "2020-01-02 10:00:00",
+						"score":     float64(7.0),
+						"time":      "2020-01-02 10:00:00",
+						"details":   "Managed AWS details - modified",
+						"resources": []byte(`[{"name": "resource name", "resources": [{"CVE": "CVE-2009-3023"}], "attributes": ["CVE"]}]`),
 					},
 				},
 			},
@@ -237,6 +246,9 @@ func TestProcessor(t *testing.T) {
 						"issue_id":  "c0000000-0000-0000-0000-000000000002",
 						"target_id": "a0000000-0000-0000-0000-000000000002",
 						"status":    "OPEN",
+						"score":     float64(9.0),
+						"details":   "Initial fixed issue details",
+						"resources": []byte(`[{"name": "resource name", "resources": [{"CVE": "CVE-8888-9999"}], "attributes": ["CVE"]}]`),
 					},
 				},
 				expectedData{
@@ -250,8 +262,10 @@ func TestProcessor(t *testing.T) {
 				expectedData{
 					table: fEventsTable,
 					data: map[string]interface{}{
-						"score": float64(9.0),
-						"time":  "2020-01-03 01:00:00",
+						"score":     float64(9.0),
+						"time":      "2020-01-03 01:00:00",
+						"details":   "Initial fixed issue details",
+						"resources": []byte(`[{"name": "resource name", "resources": [{"CVE": "CVE-8888-9999"}], "attributes": ["CVE"]}]`),
 					},
 				},
 			},
@@ -277,6 +291,8 @@ func TestProcessor(t *testing.T) {
 						"status":    "OPEN",
 						"score":     float64(6.0),
 						// Score is overwritten by latest check. TODO: Rethink about this situation.
+						"details":   "Initial fixed issue details - modified",
+						"resources": []byte(`[{"name": "resource name", "resources": [{"CVE": "CVE-9999-9999"}], "attributes": ["CVE"]}]`),
 					},
 				},
 				expectedData{
@@ -290,8 +306,10 @@ func TestProcessor(t *testing.T) {
 				expectedData{
 					table: fEventsTable,
 					data: map[string]interface{}{
-						"score": float64(6.0),
-						"time":  "2020-01-03 01:00:00",
+						"score":     float64(6.0),
+						"time":      "2020-01-03 01:00:00",
+						"details":   "Initial fixed issue details - modified",
+						"resources": []byte(`[{"name": "resource name", "resources": [{"CVE": "CVE-9999-9999"}], "attributes": ["CVE"]}]`),
 					},
 				},
 			},
@@ -341,15 +359,19 @@ func TestProcessor(t *testing.T) {
 				expectedData{
 					table: findingsTable,
 					data: map[string]interface{}{
-						"status": "OPEN",
-						"score":  float64(5.0),
+						"status":    "OPEN",
+						"score":     float64(5.0),
+						"details":   "New issue one details",
+						"resources": []byte(`[{"name": "resource name", "resources": [{"CVE": "CVE-0000-0001"}], "attributes": ["CVE"]}]`),
 					},
 				},
 				expectedData{
 					table: fEventsTable,
 					data: map[string]interface{}{
-						"score": float64(5.0),
-						"time":  "2020-01-04 01:00:00",
+						"score":     float64(5.0),
+						"time":      "2020-01-04 01:00:00",
+						"details":   "New issue one details",
+						"resources": []byte(`[{"name": "resource name", "resources": [{"CVE": "CVE-0000-0001"}], "attributes": ["CVE"]}]`),
 					},
 				},
 				expectedData{
@@ -376,15 +398,19 @@ func TestProcessor(t *testing.T) {
 						// due to just retrieved issue, which
 						// will lead to new finding 'two'
 						// being retrieved instead of 'one'.
-						"status": "OPEN",
-						"score":  float64(6.0),
+						"status":    "OPEN",
+						"score":     float64(6.0),
+						"details":   "New issue two details",
+						"resources": []byte(`[{"name": "resource name", "resources": [{"CVE": "CVE-0000-0002"}], "attributes": ["CVE"]}]`),
 					},
 				},
 				expectedData{
 					table: fEventsTable,
 					data: map[string]interface{}{
-						"score": float64(6.0),
-						"time":  "2020-01-04 01:00:00",
+						"score":     float64(6.0),
+						"time":      "2020-01-04 01:00:00",
+						"details":   "New issue two details",
+						"resources": []byte(`[{"name": "resource name", "resources": [{"CVE": "CVE-0000-0002"}], "attributes": ["CVE"]}]`),
 					},
 				},
 				expectedData{
@@ -427,8 +453,10 @@ func TestProcessor(t *testing.T) {
 				expectedData{
 					table: findingsTable,
 					data: map[string]interface{}{
-						"status": "OPEN",
-						"score":  float64(9.0),
+						"status":    "OPEN",
+						"score":     float64(9.0),
+						"details":   "Initial expired issue details",
+						"resources": []byte(`[{"name": "resource name", "resources": [{"CVE": "CVE-1111-1111"}], "attributes": ["CVE"]}]`),
 					},
 				},
 				expectedData{

--- a/test/reports_mock.go
+++ b/test/reports_mock.go
@@ -99,10 +99,11 @@ var (
 					{
 						"summary":"Managed AWS databases using CA about to expire",
 						"score":8.0,
+						"details":"Managed AWS details",
 						"cwe_id": 216,
 						"description":"Mock description",
 						"references":[],
-						"resources":[]
+						"resources":[{"name":"resource name"}]
 					}
 				],
 			"start_time":"2020-01-21 16:03:13",
@@ -122,10 +123,11 @@ var (
 				{
 					"summary":"Initial issue",
 					"score":7.0,
+					"details":"Managed AWS details - modified",
 					"cwe_id": 1,
 					"description":"Initial issue description",
 					"references":[],
-					"resources":[]
+					"resources":[{"name":"resource name", "rows": [{"CVE":"CVE-2009-3023"}], "header": ["CVE"]}]
 				}
 			],
 			"start_time":"2020-01-02 09:00:00",
@@ -138,10 +140,11 @@ var (
 				{
 					"summary":"Initial fixed issue",
 					"score":9.0,
+					"details":"Initial fixed issue details",
 					"cwe_id": 2,
 					"description":"Initial fixed issue description",
 					"references":[],
-					"resources":[]
+					"resources":[{"name":"resource name", "rows": [{"CVE":"CVE-8888-9999"}], "header": ["CVE"]}]
 				}
 			],
 			"start_time":"2020-01-03 00:00:00",
@@ -154,10 +157,11 @@ var (
 				{
 					"summary":"Initial fixed issue",
 					"score":6.0,
+					"details":"Initial fixed issue details - modified",
 					"cwe_id": 2,
 					"description":"Initial fixed issue description",
 					"references":[],
-					"resources":[]
+					"resources":[{"name":"resource name", "rows": [{"CVE":"CVE-9999-9999"}], "header": ["CVE"]}]
 				}
 			],
 			"start_time":"2020-01-03 00:00:00",
@@ -170,18 +174,20 @@ var (
 				{
 					"summary":"New issue one",
 					"score":5.0,
+					"details":"New issue one details",
 					"cwe_id": 3,
 					"description":"New issue one description",
 					"references":[],
-					"resources":[]
+					"resources":[{"name":"resource name", "rows": [{"CVE":"CVE-0000-0001"}], "header": ["CVE"]}]
 				},
 				{
 					"summary":"New issue two",
 					"score":6.0,
+					"details":"New issue two details",
 					"cwe_id": 4,
 					"description":"New issue two description",
 					"references":[],
-					"resources":[]
+					"resources":[{"name":"resource name", "rows": [{"CVE":"CVE-0000-0002"}], "header": ["CVE"]}]
 				}
 			],
 			"start_time":"2020-01-04 00:00:00",
@@ -194,10 +200,11 @@ var (
 				{
 					"summary":"Initial expired issue",
 					"score":9.0,
+					"details":"Initial expired issue details",
 					"cwe_id": 2,
 					"description":"Initial expired issue description",
 					"references":[],
-					"resources":[]
+					"resources":[{"name":"resource name", "rows": [{"CVE":"CVE-1111-1111"}], "header": ["CVE"]}]
 				}
 			],
 			"start_time":"2020-03-02 00:00:00",
@@ -218,6 +225,7 @@ var (
 				{
 					"summary":"Initial issue",
 					"score":7.0,
+					"details":"Initial issue details - concurrent",
 					"cwe_id": 1,
 					"description":"Initial issue description",
 					"references":[],
@@ -243,6 +251,7 @@ var (
 				{
 					"summary":"Initial issue",
 					"score":7.0,
+					"details":"Initial issue details - concurrent",
 					"cwe_id": 1,
 					"description":"Initial issue description",
 					"references":[],
@@ -260,6 +269,7 @@ var (
 				{
 					"summary":"Initial issue",
 					"score":7.0,
+					"details":"Initial issue details - concurrent",
 					"cwe_id": 1,
 					"description":"Initial issue description",
 					"references":[],

--- a/test/utils.go
+++ b/test/utils.go
@@ -17,13 +17,16 @@ import (
 	_ "github.com/lib/pq" // postgres driver
 )
 
+var (
+	dbPort = "5432" //default port, can be overriden by TEST_DB_PORT environment variable
+)
+
 const (
 	// DB Conn. str template.
 	dbConnStrFmt = "host=%s port=%s user=%s password=%s dbname=%s sslmode=%s"
 
 	// Test DB config.
 	dbHost    = "127.0.0.1"
-	dbPort    = "5432"
 	dbUser    = "vulndb_test"
 	dbPass    = "vulndb_test"
 	dbName    = "vulndb_test"
@@ -45,6 +48,12 @@ const (
 	fExposuresStmt = "SELECT * FROM finding_exposures WHERE finding_id = :finding_id AND found_at = :found_at"
 	tTagsStmt      = "SELECT * FROM target_tags WHERE target_id = :target_id"
 )
+
+func init() {
+	if envDBPort := os.Getenv("TEST_DB_PORT"); envDBPort != "" {
+		dbPort = envDBPort
+	}
+}
 
 // dbConnStr returns the connection
 // str for postgres test db.


### PR DESCRIPTION
This pull request modifies the DB schema and consumer to keep track of the Details and Resources at Finding Events level, in the same way we are doing for the Score field already. Also, we are going to keep the most recent information of Details and Resources at Findings levels too.

This fix the issue related with Findings not being updated with newer information (Details and Resources)

One of the important consequences of this PR is that every finding event will keep the full content of Details and Resources, generating the need for much more space in disk. For example, imagine a Finding entry that is currently occupying 100kb, only for Details and Resources. After implementing this PR, every time a new finding event is recorded, this new EVENT entry will occupy 100kb also. Depending on the frequency we generate new finding events, the database can possibly run out of space quickly. 

The plan is to have this PR merged and observe how disk space usage will change. If the difference between Finding Event entries is low enough, then we will create another PR de-normalising the columns "Details" and "Resources" from finding_events table (in other words, finding_events will just keep references to newly to-be-created DETAILS and RESOURCES tables). This will alleviate the problem with disk usage.

Also, I am including two niceties, for the easiness of running tests: 
- The ability to use an env var to define a custom DB port for tests
- The ability to set a custom endpoint for SQS and SNS
