### PR TITLE
Log message when discarding invalid reports

### DIFF
--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -122,6 +122,8 @@ func (p *CheckProcessor) ProcessMessage(m string) error {
 		if err == ErrInvalidReport {
 			// If report is invalid, return nil
 			// so mssg is deleted from queue.
+			p.logger.Warnf("Ignoring check %s due to invalid report",
+				check.ID)
 			err = nil
 		}
 		return err
@@ -192,6 +194,7 @@ func (p *CheckProcessor) parseCheckReport(reportURL string) (time.Time, []report
 		if err == results.ErrInvalidURL || err == results.ErrInvalidRespStatus {
 			// If error is due to invalid report URL
 			// or invalid HTTP status code, discard report.
+			p.logger.Warnf("Discarding report %s due to err: %s", reportURL, err)
 			err = ErrInvalidReport
 		}
 		return time.Now(), nil, err


### PR DESCRIPTION
This PR enables the logging of discarded messages due errors when downloading the report from Vulcan Results.