### PR TITLE
Add SQS message log

### DIFF
--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -100,14 +100,10 @@ func (p *CheckProcessor) ProcessMessage(m string) error {
 	// regarding the status and stats of the findings related to the source in
 	// the message can be inconsistent while the the message is being
 	// processed.
+
 	check, err := parseCheckMssg(m)
 	if err != nil {
 		return err
-	}
-	if check.Status != statusFinished {
-		p.logger.Warnf("Ignoring check %s with status %s",
-			check.ID, check.Status)
-		return nil
 	}
 
 	l := p.logger.WithFields(log.Fields{
@@ -116,14 +112,20 @@ func (p *CheckProcessor) ProcessMessage(m string) error {
 		"tag":      check.Tag,
 	})
 
+	if check.Status != statusFinished {
+		l.Warnf("Ignoring check with status %s", check.Status)
+		return nil
+	}
+
 	l.WithFields(log.Fields{"report_url": check.Report}).Debug("Parsing report")
 	checkTime, vulns, err := p.parseCheckReport(check.Report)
 	if err != nil {
 		if err == ErrInvalidReport {
 			// If report is invalid, return nil
 			// so mssg is deleted from queue.
-			p.logger.Warnf("Ignoring check %s due to invalid report",
-				check.ID)
+			l.WithFields(
+				log.Fields{"report_url": check.Report},
+			).Warn("Ignoring check due to invalid report")
 			err = nil
 		}
 		return err

--- a/pkg/queue/sqs.go
+++ b/pkg/queue/sqs.go
@@ -158,6 +158,7 @@ func (c *SQSConsumer) readAndProcess(ctx context.Context) error {
 		}
 
 		// If message is valid, process it
+		c.logger.Debugf("Processing SQS message: %s", *mssg.Body)
 		if err = c.processor.ProcessMessage(*mssg.Body); err != nil {
 			c.logger.Errorf("Error processing SQS message: %s", err.Error())
 			continue


### PR DESCRIPTION
This PR adds a new Debug level logging in order to log the whole SQS message body when reading it from the queue.
Also refactors a little bit the `Processor` logging in order to leverage the Logrus log entry initialized with the check data fields.