### PR TITLE
Ignore tags when processing targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ venv/
 *.swo
 
 local.env
+local.toml

--- a/_resources/config/local.toml.example
+++ b/_resources/config/local.toml.example
@@ -21,6 +21,9 @@ queue_arn = "arn:aws:sqs:xxx:123456789012:yyy"
 topic_arn = "arn:aws:sns:xxx:123456789012:yyy"
 enabled = true
 
+[report]
+url_replace = "https://results.vulcan.example.com|http://localhost:8081"
+
 [maintenance]
 # periodical tasks executed in background
 # - name: Custom task name

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -132,7 +132,7 @@ func (p *CheckProcessor) ProcessMessage(m string) error {
 	}
 
 	l.Debug("Processing target")
-	target, err := p.processTarget(check.Target, check.Tag)
+	target, err := p.processTarget(check.Target)
 	if err != nil {
 		return err
 	}
@@ -163,12 +163,12 @@ func (p *CheckProcessor) ProcessMessage(m string) error {
 
 // processTarget creates a new target in the vulnerability db for the given identifier
 // and returns the created target if it does not exist. If target already exists returns it.
-func (p *CheckProcessor) processTarget(identifier, tag string) (*store.Target, error) {
+func (p *CheckProcessor) processTarget(identifier string) (*store.Target, error) {
 	target := store.Target{
 		Identifier: identifier,
 	}
 
-	return p.store.CreateTargetIfNotExists(target, []string{tag})
+	return p.store.CreateTarget(target)
 }
 
 func (p *CheckProcessor) sourceFromCheck(c CheckMessage, targetID string, t time.Time) store.Source {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -10,8 +10,7 @@ import "time"
 // the vulnerability database adapter.
 type VulnStore interface {
 	// Targets
-	CreateTarget(t Target, tags []string) (*Target, error)
-	CreateTargetIfNotExists(t Target, tags []string) (*Target, error)
+	CreateTarget(t Target) (*Target, error)
 	FindTarget(t Target) (*Target, error)
 
 	// Sources

--- a/pkg/store/targets.go
+++ b/pkg/store/targets.go
@@ -4,6 +4,8 @@ Copyright 2020 Adevinta
 
 package store
 
+import "context"
+
 // Target represents the target
 // scope for a check execution.
 type Target struct {
@@ -11,50 +13,28 @@ type Target struct {
 	Identifier string
 }
 
-func (db *psqlxStore) CreateTargetIfNotExists(t Target, tags []string) (*Target, error) {
-	_, err := db.DB.Exec("INSERT INTO targets (identifier) VALUES ($1)", t.Identifier)
-	if err != nil && !IsDuplicateErr(err) { // Target might exist but with a different tag.
-		return nil, err
-	}
+func (db *psqlxStore) CreateTarget(t Target) (*Target, error) {
+	var created Target
 
-	target, err := db.FindTarget(t)
-	if err != nil {
-		return nil, err
-	}
+	query := `
+	WITH  exists_query as (
+    SELECT * FROM targets 
+	WHERE identifier=$1
+	), 
+	create_query AS (
+      INSERT INTO targets (identifier) 
+      SELECT $1
+      WHERE NOT EXISTS (SELECT 1 FROM exists_query)
+      RETURNING *
+    )
+    SELECT * FROM create_query
+    UNION ALL
+	SELECT * FROM exists_query`
 
-	for _, tag := range tags {
-		if len(tag) == 0 {
-			continue
-		}
-		err = db.createTargetTag(target.ID, tag)
-		if err != nil && !IsDuplicateErr(err) {
-			return nil, err
-		}
-	}
-	return target, nil
-}
+	row := db.DB.QueryRowContext(context.Background(), query, t.Identifier)
+	err := row.Scan(&created.ID, &created.Identifier)
+	return &created, err
 
-func (db *psqlxStore) CreateTarget(t Target, tags []string) (*Target, error) {
-	_, err := db.DB.Exec("INSERT INTO targets (identifier) VALUES ($1)", t.Identifier)
-	if err != nil {
-		return nil, err
-	}
-
-	target, err := db.FindTarget(t)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, tag := range tags {
-		if len(tag) == 0 {
-			continue
-		}
-		err = db.createTargetTag(target.ID, tag)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return target, err
 }
 
 func (db *psqlxStore) FindTarget(t Target) (*Target, error) {
@@ -65,9 +45,4 @@ func (db *psqlxStore) FindTarget(t Target) (*Target, error) {
 	}
 
 	return &foundTarget, nil
-}
-
-func (db *psqlxStore) createTargetTag(targetID, tag string) error {
-	_, err := db.DB.Exec("INSERT INTO target_tags (target_id, tag) VALUES ($1, $2)", targetID, tag)
-	return err
 }

--- a/test/processor_integration_test.go
+++ b/test/processor_integration_test.go
@@ -31,7 +31,6 @@ const (
 	issuesTable     = "issues"
 	sourcesTable    = "sources"
 	targetsTable    = "targets"
-	tTagsTable      = "target_tags"
 
 	// timeFmt.
 	timeFmt = "2006-01-02 15:04:05"
@@ -108,12 +107,6 @@ func TestProcessor(t *testing.T) {
 					table: targetsTable,
 					data: map[string]interface{}{
 						"identifier": "www.adevinta.com",
-					},
-				},
-				expectedData{
-					table: tTagsTable,
-					data: map[string]interface{}{
-						"tag": "adrn:adevinta:team:security",
 					},
 				},
 				expectedData{
@@ -339,12 +332,6 @@ func TestProcessor(t *testing.T) {
 					table: targetsTable,
 					data: map[string]interface{}{
 						"identifier": "www.new.example.com",
-					},
-				},
-				expectedData{
-					table: tTagsTable,
-					data: map[string]interface{}{
-						"tag": "adrn:adevinta:team:new",
 					},
 				},
 				expectedData{

--- a/test/utils.go
+++ b/test/utils.go
@@ -46,7 +46,6 @@ const (
 	findingsStmt   = "SELECT id as finding_id, * FROM findings WHERE issue_id = :issue_id AND target_id = :target_id"
 	fEventsStmt    = "SELECT * FROM finding_events WHERE finding_id = :finding_id AND time = :time"
 	fExposuresStmt = "SELECT * FROM finding_exposures WHERE finding_id = :finding_id AND found_at = :found_at"
-	tTagsStmt      = "SELECT * FROM target_tags WHERE target_id = :target_id"
 )
 
 func init() {
@@ -130,8 +129,6 @@ func fetchDBData(table string, args map[string]interface{}, db *sqlx.DB) (map[st
 		stmt = fEventsStmt
 	case fExposuresTable:
 		stmt = fExposuresStmt
-	case tTagsTable:
-		stmt = tTagsStmt
 	}
 
 	if stmt == "" {


### PR DESCRIPTION
This PR modifies VulnDB consumer in order to ignore the tag information included in the check messages, therefore targets - tags association won't be responsibility of the consumer, instead that will be handled between Vulcan API - VulnDB API, see [vulcan-api PR #11](https://github.com/adevinta/vulcan-api/pull/11).

The reason for this change is that there could be a mismatch of the data regarding the _team - target_ association between the moment on which a scan is created and that scan's checks are processed by the vulndb consumer. Basically we can not guarantee that the ownership expressed in the check messages tags association is correct once the check message is being processed.
See this example for instance:

- 10:00 AM : scans for teamA are created including at least 1 check for asset A1
- 11:00 AM : check for asset A1 is executed
- 11:30 AM : a user from teamA deletes the asset A1 from its team, this triggers a DELETE operation on the VulnDB to deasociate that asset at the VulnDB level from the teamA
- 11:45 AM : the check executed for asset A1 is processed by the VulnDB. Because this check contained the association with the team teamA (because at the time when the check was created it belonged to that team) the asset A1 is associated with teamA at the VulnDB level.
