### PR TITLE
Improve createSource func and remove unused createSourceIfNotExists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/adevinta/vulcan-report v0.0.0-20190503133936-d8a2d4cb18ff
 	github.com/aws/aws-sdk-go v1.21.6
 	github.com/go-sql-driver/mysql v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/adevinta/vulcan-report v0.0.0-20190503133936-d8a2d4cb18ff h1:ZazuZSOfV8oo70SWdjLQi+In4GSmJCA2rwsliyz9KNs=
 github.com/adevinta/vulcan-report v0.0.0-20190503133936-d8a2d4cb18ff/go.mod h1:GtAon6TymHFTOPwRdR7SHun/TSM1kyPMQYXxGLTR8eQ=
 github.com/aws/aws-sdk-go v1.21.6 h1:3GuIm55Uls52aQIDGBnSEZbk073jpasfQyeM5eZU61Q=

--- a/pkg/store/sources.go
+++ b/pkg/store/sources.go
@@ -67,29 +67,12 @@ type SourceFinding struct {
 	Resources     *[]byte
 }
 
-func (db *psqlxStore) CreateSourceIfNotExists(s Source) (*Source, error) {
-
-	tx, err := db.DB.BeginTxx(context.Background(), nil)
-	if err != nil {
-		return nil, err
-	}
-	source, err := createSourceIfNotExists(context.Background(), tx, s)
-	if err != nil {
-		return nil, err
-	}
-	err = tx.Commit()
-	if err != nil {
-		return nil, err
-	}
-	return source, nil
-}
-
 // GetOpenSourceFindings returns the tuple issue_id,score for the findings that
 // have been found by a given the source.
 func (db *psqlxStore) GetOpenSourceFindings(id string) ([]SourceFinding, error) {
 	openFindingsForSource := `
 	SELECT distinct f.issue_id as issue_id, fe.score as score
-	FROM findings f JOIN finding_events fe on fe.finding_id=f.id 
+	FROM findings f JOIN finding_events fe on fe.finding_id=f.id
 	JOIN sources s on s.id = fe.source_id
 	WHERE f.status='OPEN' AND fe.source_id = $1`
 	sf := []SourceFinding{}
@@ -265,40 +248,37 @@ func (db *psqlxStore) lockTxBySources(tx *sqlx.Tx, sff SourceFamilies) error {
 }
 
 func createSource(ctx context.Context, tx *sqlx.Tx, s Source) (*Source, error) {
-	r := tx.QueryRowxContext(ctx, `INSERT INTO sources (name, component, instance, options, time, target_id) 
-	  VALUES ($1, $2, $3, $4, $5, $6) RETURNING *`, s.Name, s.Component, s.Instance, s.Options, s.Time, s.Target)
+	r := tx.QueryRowxContext(ctx,
+		`INSERT INTO sources (name, component, instance, options, time, target_id)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT ON CONSTRAINT sources_name_component_instance_options_key DO NOTHING
+		RETURNING *`,
+		s.Name, s.Component, s.Instance, s.Options, s.Time, s.Target)
 	err := r.StructScan(&s)
+
+	// If insert conflicts due to constraint, we don't want the transaction to fail
+	// and we want to return the source that already exists in the db.
+	// ON CONFLICT ON CONSTRAINT DO NOTHING will return an empty row if insert fail
+	// due to target CONSTRAINT and therefore the record we want to create exists.
+	if IsNotFoundErr(err) {
+		q := `SELECT * FROM sources
+			WHERE name=$1 AND component=$2 AND instance=$3 AND options=$4 AND time=$5 AND target_id=$6`
+
+		row := tx.QueryRowContext(ctx, q,
+			s.Name, s.Component, s.Instance, s.Options, s.Time, s.Target)
+		var existingSource Source
+		errExistingSource := row.Scan(&existingSource.ID, &existingSource.Name, &existingSource.Component,
+			&existingSource.Instance, &existingSource.Options, &existingSource.Time, &existingSource.Target)
+		if errExistingSource != nil {
+			return nil, errExistingSource
+		}
+		return &existingSource, nil
+	}
+
 	if err != nil {
 		return nil, err
 	}
 	return &s, nil
-}
-
-func createSourceIfNotExists(ctx context.Context, tx *sqlx.Tx, s Source) (*Source, error) {
-	var err error
-	q := `
-	WITH  q as (
-    SELECT * FROM sources 
-	WHERE name=$1 AND component=$2 AND instance=$3 AND options=$4
-	), 
-	c AS (
-      INSERT INTO sources (name, component, instance, options, time, target_id) 
-      SELECT $1, $2, $3, $4, $5, $6
-      WHERE NOT EXISTS (SELECT 1 FROM q)
-      RETURNING *
-    )
-    SELECT * FROM c
-    UNION ALL
-	SELECT * FROM q`
-
-	r := tx.QueryRowContext(ctx, q,
-		s.Name, s.Component, s.Instance, s.Options, s.Time, s.Target)
-	var created Source
-
-	err = r.Scan(&created.ID, &created.Name, &created.Component, &created.Instance,
-		&created.Options, &created.Time, &created.Target)
-
-	return &created, err
 }
 
 // updateLastSource inserts or updates information about last source for specified finding.

--- a/pkg/store/sources_test.go
+++ b/pkg/store/sources_test.go
@@ -5,9 +5,121 @@ Copyright 2020 Adevinta
 package store
 
 import (
+	"context"
+	"database/sql/driver"
 	"reflect"
 	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
 )
+
+var (
+	tTime   = time.Now()
+	tSource = Source{
+		ID:       "id_source_1",
+		Instance: "id_check_1",
+		SourceFamily: SourceFamily{
+			Name:      "family_1",
+			Component: "vulcan",
+			Target:    "api.example.com",
+		},
+		Time: tTime,
+	}
+	createSourceQueryArgs = []driver.Value{
+		tSource.Name,
+		tSource.Component,
+		tSource.Instance,
+		tSource.Options,
+		tSource.Time,
+		tSource.Target,
+	}
+)
+
+func TestCreateSource(t *testing.T) {
+	tests := []struct {
+		name               string
+		insertRowsResponse *sqlmock.Rows
+		selectRowsResponse *sqlmock.Rows
+		expectErr          bool
+		inputSource        *Source
+		expectedSource     *Source
+	}{
+		{
+			name: "CreateNonExistingSource",
+			insertRowsResponse: sqlmock.NewRows(
+				[]string{"id", "name", "component", "instance", "options", "time", "target_id"},
+			).AddRow(
+				"id_source_1", "family_1", "vulcan", "id_check_1", "", tTime, "api.example.com",
+			),
+			expectErr:      false,
+			inputSource:    &tSource,
+			expectedSource: &tSource,
+		},
+		{
+			name:               "CreateExistingSource",
+			insertRowsResponse: sqlmock.NewRows([]string{}),
+			selectRowsResponse: sqlmock.NewRows(
+				[]string{"id", "name", "componet", "instance", "options", "time", "target_id"},
+			).AddRow(
+				tSource.ID, tSource.Name, tSource.Component, tSource.Instance, tSource.Options, tSource.Time, tSource.Target,
+			),
+			expectErr:      false,
+			inputSource:    &tSource,
+			expectedSource: &tSource,
+		},
+		{
+			name:               "CreateMalformedNonExistingSource",
+			insertRowsResponse: sqlmock.NewRows([]string{}),
+			expectErr:          true,
+			inputSource:        &Source{},
+			expectedSource:     nil,
+		},
+		{
+			name:               "CreateMalformedExistingSource",
+			insertRowsResponse: sqlmock.NewRows([]string{}),
+			selectRowsResponse: sqlmock.NewRows([]string{}),
+			expectErr:          true,
+			inputSource:        &tSource,
+			expectedSource:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockDB, mock, _ := sqlmock.New()
+			defer mockDB.Close()
+			sqlxDB := sqlx.NewDb(mockDB, "sqlmock")
+
+			mock.ExpectBegin()
+			mock.ExpectQuery("INSERT INTO").
+				WithArgs(createSourceQueryArgs...).
+				WillReturnRows(tt.insertRowsResponse)
+
+			if tt.selectRowsResponse != nil {
+				mock.ExpectQuery("^SELECT (.+) FROM sources").
+					WithArgs(createSourceQueryArgs...).
+					WillReturnRows(tt.selectRowsResponse)
+			}
+			ctx := context.Background()
+			tx, _ := sqlxDB.BeginTxx(ctx, nil)
+			screated, err := createSource(ctx, tx, *tt.inputSource)
+			if tt.expectErr && err == nil {
+				t.Errorf("an error was expected creating source: %s in test: %s", err, tt.name)
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("unexpected error creating source: %s", err)
+			}
+			if tt.expectErr && err != nil {
+				return
+			}
+			if !reflect.DeepEqual(*screated, *tt.expectedSource) {
+				t.Errorf("expected source: %#v does not match created source: %#v", tt.expectedSource, screated)
+			}
+		})
+	}
+}
 
 func TestSortSourceFamilies(t *testing.T) {
 	tests := []struct {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -15,7 +15,6 @@ type VulnStore interface {
 
 	// Sources
 	CreateSource(s Source) (*Source, error)
-	CreateSourceIfNotExists(s Source) (*Source, error)
 	FindSource(s Source) (*Source, error)
 	SourceFamilies() (SourceFamilies, error)
 	ProcessSourceExecution(s Source, finding []SourceFinding) (Source, error)


### PR DESCRIPTION
This PR tries to improve reliability when reprocessing messages.
In case a message is processed more than once a race condition may happen if `source` entity for the message has been created but issues/findings not processed.
This scenario is very unlikely but can certainly happen an is annoying when developing.