### PR TITLE
Sanitize JSONB fields

### DIFF
--- a/pkg/store/findings.go
+++ b/pkg/store/findings.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -145,7 +146,7 @@ func (db *psqlxStore) CreateFinding(eventTime time.Time, f Finding, sourceID str
 
 	// Create finding.
 	_, err = tx.Exec("INSERT INTO findings (issue_id, target_id, affected_resource, affected_resource_string, fingerprint, score, status, details, resources) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
-		f.IssueID, f.TargetID, f.AffectedResource, f.AffectedResourceString, f.Fingerprint, f.Score, f.Status, f.Details, f.Resources)
+		f.IssueID, f.TargetID, f.AffectedResource, f.AffectedResourceString, f.Fingerprint, f.Score, f.Status, f.Details, sanitizeJSONB(f.Resources))
 	if err != nil {
 		tx.Rollback()
 		return nil, err
@@ -346,7 +347,7 @@ func createFindingEvent(ctx context.Context, tx *sqlx.Tx, f Finding, s Source, s
 	UNION ALL
 	SELECT id FROM q
 	`
-	err := tx.Get(&f, q, f.IssueID, f.TargetID, f.AffectedResource, affectedResourceString, f.Fingerprint, score, f.Status, f.Details, f.ImpactDetails, f.Resources)
+	err := tx.Get(&f, q, f.IssueID, f.TargetID, f.AffectedResource, affectedResourceString, f.Fingerprint, score, f.Status, f.Details, f.ImpactDetails, sanitizeJSONB(f.Resources))
 	if err != nil {
 		return nil, err
 	}
@@ -354,7 +355,7 @@ func createFindingEvent(ctx context.Context, tx *sqlx.Tx, f Finding, s Source, s
 	// Create the finding event.
 	var findingEvent FindingEvent
 	r := tx.QueryRowxContext(ctx, `INSERT INTO finding_events (finding_id, source_id, time, score, resources, details, fingerprint, affected_resource_string)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *`, f.ID, s.ID, s.Time, score, f.Resources, f.Details, f.Fingerprint, affectedResourceString)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *`, f.ID, s.ID, s.Time, score, sanitizeJSONB(f.Resources), f.Details, f.Fingerprint, affectedResourceString)
 	err = r.StructScan(&findingEvent)
 	return &findingEvent, err
 }
@@ -712,4 +713,16 @@ func replaceFindingsState(ctx context.Context, tx *sqlx.Tx, l *log.Logger, state
 		}
 	}
 	return nil
+}
+
+// sanitizeJSONB sanitizes a JSON string to comply with PostgreSQL
+// restrictions for unicode escape sequences, particularly for the
+// NULL character (\u0000).
+// See doc: https://www.postgresql.org/docs/10/datatype-json.html.
+func sanitizeJSONB(jsonb *[]byte) *[]byte {
+	if jsonb == nil {
+		return jsonb
+	}
+	sanitized := []byte(strings.Replace(string(*jsonb), "\\u0000", "", -1))
+	return &sanitized
 }

--- a/test/processor_integration_test.go
+++ b/test/processor_integration_test.go
@@ -1770,6 +1770,73 @@ func TestProcessor(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Should handle NULL unicode character",
+			checkData: `
+				{
+			        "id":"uuuuuuuu-0000-0000-0000-000000000001",
+			        "checktype_name":"vulcan-unicode-check",
+			        "status":"FINISHED",
+			        "target":"unicode.example.com",
+			        "options":"{}",
+			        "report":"https://dummy.com/v1/reports/uuuuuuuu-0000-0000-0000-000000000001.json",
+			        "tag":"adrn:adevinta:team:security"
+				}`,
+			expected: []expectedData{
+				expectedData{
+					table: issuesTable,
+					data: map[string]interface{}{
+						"summary":     "Unicode character vulnerability",
+						"description": "Unicode character vulnerability description",
+						"cwe_id":      int64(2),
+					},
+				},
+				expectedData{
+					table: targetsTable,
+					data: map[string]interface{}{
+						"identifier": "unicode.example.com",
+					},
+				},
+				expectedData{
+					table: sourcesTable,
+					data: map[string]interface{}{
+						"name":      "vulcan",
+						"component": "vulcan-unicode-check",
+						"instance":  "uuuuuuuu-0000-0000-0000-000000000001",
+						"options":   "{}",
+					},
+				},
+				expectedData{
+					table: findingsTable,
+					data: map[string]interface{}{
+						"status":            "OPEN",
+						"score":             float64(6.0),
+						"details":           "",
+						"affected_resource": "unicode.example.com/encoding",
+						"fingerprint":       "default",
+						"resources":         []byte(`[{"name": "Unicode character", "resources": [{"String": "unicodechar\u0002h)h-C\by\u001e\u0001..."}], "attributes": ["String"]}]`),
+					},
+				},
+				expectedData{
+					table: fEventsTable,
+					data: map[string]interface{}{
+						"time":        "2022-01-01 16:03:25",
+						"score":       float64(6.0),
+						"details":     "",
+						"fingerprint": "default",
+						"resources":   []byte(`[{"name": "Unicode character", "resources": [{"String": "unicodechar\u0002h)h-C\by\u001e\u0001..."}], "attributes": ["String"]}]`),
+					},
+				},
+				expectedData{
+					table: fExposuresTable,
+					data: map[string]interface{}{
+						"found_at": "2022-01-01 16:03:25",
+						"fixed_at": nil,
+						"ttr":      nil,
+					},
+				},
+			},
+		},
 	}
 
 	testDB, err := db()

--- a/test/reports_mock.go
+++ b/test/reports_mock.go
@@ -576,6 +576,26 @@ var (
 			"start_time":"2021-01-21 16:03:13",
 			"end_time":"2021-01-21 16:03:25"
 		}`,
+		// Report that contains a NULL unicode character that must be escaped.
+		`{
+			"check_id":"uuuuuuuu-0000-0000-0000-000000000001",
+			"vulnerabilities":
+				[
+					{
+						"summary":"Unicode character vulnerability",
+						"score":6.0,
+						"details":"",
+						"cwe_id": 2,
+						"description":"Unicode character vulnerability description",
+						"references":[],
+						"affected_resource":"unicode.example.com/encoding",
+						"fingerprint":"default",
+						"resources":[{"Name":"Unicode character","Header":["String"],"Rows":[{"String":"\u0000\u0000\u0000unicodechar\u0002\u0000h)h-C\u0008y\u001e\u0001\u0000\u0000..."}]}]
+					}
+				],
+			"start_time":"2022-01-01 16:03:13",
+			"end_time":"2022-01-01 16:03:25"
+		}`,
 		// Processor Concurrency:
 		// Report that adds new finding event to initial finding.
 		`{


### PR DESCRIPTION
This PR puts mechanisms in place in order to sanitize JSONB fields (currently only affected findings and finding events resources fields) following the restrictions that apply for PostgreSQL database, particularly for the NULL unicode character (\u0000).
See documentation: https://www.postgresql.org/docs/10/datatype-json.html.