### PR TITLE
Upgrade Flyway

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 env:
   global:
     - CGO_ENABLED=0
-    - FLYWAY_VERSION=9.1.4
+    - FLYWAY_VERSION=9.4.0
     - INPUT_BUILDARGS=FLYWAY_VERSION=$FLYWAY_VERSION
 before_install:
   # Requirement for 'test-local-deployment'

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /flyway
 
 RUN apk add --no-cache --update openjdk8-jre-base bash gettext
 
-ARG FLYWAY_VERSION=9.1.4
+ARG FLYWAY_VERSION=9.4.0
 
 RUN wget https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz \
     && tar -xzf flyway-commandline-${FLYWAY_VERSION}.tar.gz --strip 1 \


### PR DESCRIPTION
This PR upgrades Flyway to v9.4.0 in order to fix some associated vulnerabilities present in dependencies:
- org.apache.commons:commons-text:1.9
- com.fasterxml.jackson.core:jackson-databind:2.13.2.1