### PR TITLE
Unicode

### DIFF
--- a/pkg/store/findings.go
+++ b/pkg/store/findings.go
@@ -7,8 +7,8 @@ package store
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -717,16 +717,13 @@ func replaceFindingsState(ctx context.Context, tx *sqlx.Tx, l *log.Logger, state
 
 // sanitizeJSONB sanitizes a JSON string to comply with PostgreSQL
 // restrictions for unicode escape sequences, particularly for the
-// NULL character (\u0000) only if not preceeded by an even number of \
+// NULL character (\u0000) replaced by space (\u0020).
+// Just removing \u0000 can generate a wrong string in this case \\u0000 (\).
 // See doc: https://www.postgresql.org/docs/10/datatype-json.html.
 func sanitizeJSONB(jsonb *[]byte) *[]byte {
 	if jsonb == nil {
 		return jsonb
 	}
-
-	// "\\u0000" "\\\\u0000" are correct
-	// "\u0000" or "\\\u0000" are not
-	m := regexp.MustCompile(`([^\\](\\\\)*)\\u0000`)
-	sanitized := []byte(m.ReplaceAllString(string(*jsonb), "${1}"))
+	sanitized := []byte(strings.Replace(string(*jsonb), "\\u0000", "\\u0020", -1))
 	return &sanitized
 }

--- a/pkg/store/findings.go
+++ b/pkg/store/findings.go
@@ -715,6 +715,8 @@ func replaceFindingsState(ctx context.Context, tx *sqlx.Tx, l *log.Logger, state
 	return nil
 }
 
+var nullCharRegExp = regexp.MustCompile(`((^|[^\\])(\\\\)*)(\\u0000)+`)
+
 // sanitizeJSONB sanitizes a JSON string to comply with PostgreSQL
 // restrictions for unicode escape sequences, particularly for the
 // NULL character (\u0000).
@@ -727,12 +729,11 @@ func sanitizeJSONB(jsonb *[]byte) *[]byte {
 	// "\\u0000" "\\\\u0000" are correct
 	// "\u0000" "\\\u0000" are not
 	s := string(*jsonb)
-	r := regexp.MustCompile(`((^|[^\\])(\\\\)*)(\\u0000)+`)
-	s2 := r.ReplaceAllString(s, "$1")
+	s2 := nullCharRegExp.ReplaceAllString(s, "$1")
 	// The check consumes the \ and no negative lookbehind is supported in regexp go package.
 	for s2 != s {
 		s = s2
-		s2 = r.ReplaceAllString(s, "$1")
+		s2 = nullCharRegExp.ReplaceAllString(s, "$1")
 	}
 	sanitized := []byte(s2)
 	return &sanitized

--- a/pkg/store/findings.go
+++ b/pkg/store/findings.go
@@ -7,8 +7,8 @@ package store
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -717,12 +717,16 @@ func replaceFindingsState(ctx context.Context, tx *sqlx.Tx, l *log.Logger, state
 
 // sanitizeJSONB sanitizes a JSON string to comply with PostgreSQL
 // restrictions for unicode escape sequences, particularly for the
-// NULL character (\u0000).
+// NULL character (\u0000) only if not preceeded by an even number of \
 // See doc: https://www.postgresql.org/docs/10/datatype-json.html.
 func sanitizeJSONB(jsonb *[]byte) *[]byte {
 	if jsonb == nil {
 		return jsonb
 	}
-	sanitized := []byte(strings.Replace(string(*jsonb), "\\u0000", "", -1))
+
+	// "\\u0000" "\\\\u0000" are correct
+	// "\u0000" or "\\\u0000" are not
+	m := regexp.MustCompile(`([^\\](\\\\)*)\\u0000`)
+	sanitized := []byte(m.ReplaceAllString(string(*jsonb), "${1}"))
 	return &sanitized
 }

--- a/pkg/store/findings.go
+++ b/pkg/store/findings.go
@@ -7,8 +7,8 @@ package store
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -717,13 +717,23 @@ func replaceFindingsState(ctx context.Context, tx *sqlx.Tx, l *log.Logger, state
 
 // sanitizeJSONB sanitizes a JSON string to comply with PostgreSQL
 // restrictions for unicode escape sequences, particularly for the
-// NULL character (\u0000) replaced by space (\u0020).
+// NULL character (\u0000)
 // Just removing \u0000 can generate a wrong string in this case \\u0000 (\).
 // See doc: https://www.postgresql.org/docs/10/datatype-json.html.
 func sanitizeJSONB(jsonb *[]byte) *[]byte {
 	if jsonb == nil {
 		return jsonb
 	}
-	sanitized := []byte(strings.Replace(string(*jsonb), "\\u0000", "\\u0020", -1))
+	// "\\u0000" "\\\\u0000" are correct
+	// "\u0000" "\\\u0000" are not
+	s := string(*jsonb)
+	r := regexp.MustCompile(`((^|[^\\])(\\\\)*)(\\u0000)+`)
+	s2 := r.ReplaceAllString(s, "$1")
+	// The check consumes the \ and no negative lookbehind is supported in regexp go package.
+	for s2 != s {
+		s = s2
+		s2 = r.ReplaceAllString(s, "$1")
+	}
+	sanitized := []byte(s2)
 	return &sanitized
 }

--- a/pkg/store/findings.go
+++ b/pkg/store/findings.go
@@ -717,7 +717,7 @@ func replaceFindingsState(ctx context.Context, tx *sqlx.Tx, l *log.Logger, state
 
 // sanitizeJSONB sanitizes a JSON string to comply with PostgreSQL
 // restrictions for unicode escape sequences, particularly for the
-// NULL character (\u0000)
+// NULL character (\u0000).
 // Just removing \u0000 can generate a wrong string in this case \\u0000 (\).
 // See doc: https://www.postgresql.org/docs/10/datatype-json.html.
 func sanitizeJSONB(jsonb *[]byte) *[]byte {

--- a/pkg/store/findings_test.go
+++ b/pkg/store/findings_test.go
@@ -442,6 +442,46 @@ func Test_buildFindingExposures(t *testing.T) {
 	}
 }
 
+func Test_SanitizeJSON(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		wanted string
+	}{
+		{
+			name:   "Happy",
+			source: `"\u0000hello\u0000"`,
+			wanted: `"hello"`,
+		},
+		{
+			name:   "NoReplace",
+			source: `"hello!\\u0000"`,
+			wanted: `"hello!\\u0000"`,
+		},
+		{
+			name:   "DontReplaceQuotedSlash",
+			source: `"\\u0000\\\\u0000\\\\\u0000\\\u0000\u0000"`,
+			wanted: `"\\u0000\\\\u0000\\\\\\"`,
+		},
+		{
+			name:   "Begin",
+			source: `\u0000hello`,
+			wanted: `hello`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := []byte(tt.source)
+			r := sanitizeJSONB(&s)
+			diff := cmp.Diff(string(*r), tt.wanted)
+			if diff != "" {
+				t.Errorf("wrong sanitize, diff %s", diff)
+			}
+		})
+	}
+}
+
 func mustParseTime(t string) time.Time {
 	r, err := time.Parse("2006-01-02 15:04:05", t)
 	if err != nil {

--- a/test/processor_integration_test.go
+++ b/test/processor_integration_test.go
@@ -1814,7 +1814,7 @@ func TestProcessor(t *testing.T) {
 						"details":           "",
 						"affected_resource": "unicode.example.com/encoding",
 						"fingerprint":       "default",
-						"resources":         []byte(`[{"name": "Unicode character", "resources": [{"String": "unicodechar\u0002h)h-C\by\u001e\u0001..."}], "attributes": ["String"]}]`),
+						"resources":         []byte(`[{"name": "Unicode character", "resources": [{"String": "\\u0020   unicodechar\u0002 h)h-C\by\u001e\u0001  ..."}], "attributes": ["String"]}]`),
 					},
 				},
 				expectedData{
@@ -1824,7 +1824,7 @@ func TestProcessor(t *testing.T) {
 						"score":       float64(6.0),
 						"details":     "",
 						"fingerprint": "default",
-						"resources":   []byte(`[{"name": "Unicode character", "resources": [{"String": "unicodechar\u0002h)h-C\by\u001e\u0001..."}], "attributes": ["String"]}]`),
+						"resources":   []byte(`[{"name": "Unicode character", "resources": [{"String": "\\u0020   unicodechar\u0002 h)h-C\by\u001e\u0001  ..."}], "attributes": ["String"]}]`),
 					},
 				},
 				expectedData{

--- a/test/processor_integration_test.go
+++ b/test/processor_integration_test.go
@@ -1814,7 +1814,7 @@ func TestProcessor(t *testing.T) {
 						"details":           "",
 						"affected_resource": "unicode.example.com/encoding",
 						"fingerprint":       "default",
-						"resources":         []byte(`[{"name": "Unicode character", "resources": [{"String": "\\u0020   unicodechar\u0002 h)h-C\by\u001e\u0001  ..."}], "attributes": ["String"]}]`),
+						"resources":         []byte(`[{"name": "Unicode character", "resources": [{"String": "\\u0000unicodechar\u0002h)h-C\by\u001e\u0001..."}], "attributes": ["String"]}]`),
 					},
 				},
 				expectedData{
@@ -1824,7 +1824,7 @@ func TestProcessor(t *testing.T) {
 						"score":       float64(6.0),
 						"details":     "",
 						"fingerprint": "default",
-						"resources":   []byte(`[{"name": "Unicode character", "resources": [{"String": "\\u0020   unicodechar\u0002 h)h-C\by\u001e\u0001  ..."}], "attributes": ["String"]}]`),
+						"resources":   []byte(`[{"name": "Unicode character", "resources": [{"String": "\\u0000unicodechar\u0002h)h-C\by\u001e\u0001..."}], "attributes": ["String"]}]`),
 					},
 				},
 				expectedData{

--- a/test/reports_mock.go
+++ b/test/reports_mock.go
@@ -590,7 +590,7 @@ var (
 						"references":[],
 						"affected_resource":"unicode.example.com/encoding",
 						"fingerprint":"default",
-						"resources":[{"Name":"Unicode character","Header":["String"],"Rows":[{"String":"\u0000\u0000\u0000unicodechar\u0002\u0000h)h-C\u0008y\u001e\u0001\u0000\u0000..."}]}]
+						"resources":[{"Name":"Unicode character","Header":["String"],"Rows":[{"String":"\\u0000\u0000\u0000\u0000unicodechar\u0002\u0000h)h-C\u0008y\u001e\u0001\u0000\u0000..."}]}]
 					}
 				],
 			"start_time":"2022-01-01 16:03:13",


### PR DESCRIPTION
`sanitizeJSONB` generates a wrong json string `\` in case of `\\u0000`.
This pr removes the \0000 only if not preceded with an odd number of \