### PR TITLE
Allow reading messages from sqs without sns envelop

### DIFF
--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -205,7 +205,7 @@ func (p *CheckProcessor) parseCheckReport(reportURL string) (time.Time, []report
 		return time.Now(), nil, err
 	}
 
-	age := int(time.Now().Sub(report.EndTime).Hours() / 24)
+	age := int(time.Since(report.EndTime).Hours() / 24)
 	if p.maxEventAge > 0 && age > p.maxEventAge {
 		p.logger.Warnf("Discarding report %s due to max age exceeded", reportURL)
 		return time.Now(), nil, ErrInvalidReport
@@ -332,9 +332,15 @@ func parseCheckMssg(m string) (*CheckMessage, error) {
 		return nil, ErrInvalidMssgFmt
 	}
 
+	// If sent in raw format try with the original payload.
+	msg := notif.Message
+	if notif.MessageID == "" && notif.Message == "" {
+		msg = m
+	}
+
 	// Parse notification's inner check data
 	check := CheckMessage{}
-	if err := json.Unmarshal([]byte(notif.Message), &check); err != nil {
+	if err := json.Unmarshal([]byte(msg), &check); err != nil {
 		return nil, ErrInvalidMssgFmt
 	}
 


### PR DESCRIPTION
When running with an sqs/sns mock environment (i.e. goaws) the message is not wrapped with an sns envelop.
This pr allows to identify this situation and try to Unmarshal  the original message.

I managed to fix goa https://github.com/adevinta/vulcan-charts/pull/116/commits/3d3239ae4b4aedc0a29be7eb5636a76a023a0362


Besides of that I found  https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html so I think the identification of the message was fair and it could be a good practice to let the component adapt to changes in the subscription. It doesn't care if it comes from an sns or right from an sqs.

In any case, we can close the pr.